### PR TITLE
Added custom version support

### DIFF
--- a/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/manager/impl/CloudAPIImpl.kt
+++ b/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/manager/impl/CloudAPIImpl.kt
@@ -32,7 +32,7 @@ import eu.thesimplecloud.api.screen.ICommandExecuteManager
 import eu.thesimplecloud.api.service.ICloudServiceManager
 import eu.thesimplecloud.api.service.version.IServiceVersionHandler
 import eu.thesimplecloud.api.service.version.ServiceVersionHandler
-import eu.thesimplecloud.api.service.version.ServiceVersionWebLoader
+import eu.thesimplecloud.api.service.version.ServiceVersionLoader
 import eu.thesimplecloud.api.servicegroup.ICloudServiceGroupManager
 import eu.thesimplecloud.api.sync.list.manager.ISynchronizedObjectListManager
 import eu.thesimplecloud.api.sync.list.manager.SynchronizedObjectListManager
@@ -52,7 +52,7 @@ class CloudAPIImpl : CloudAPI() {
     private val wrapperManager = WrapperManagerImpl()
     private val eventManager = EventManagerImpl()
     private val synchronizedObjectListManager = SynchronizedObjectListManager()
-    private val serviceVersionHandler = ServiceVersionHandler(ServiceVersionWebLoader.loadVersions())
+    private val serviceVersionHandler = ServiceVersionHandler(ServiceVersionLoader.loadVersions())
     private val languageManager = LanguageManagerImpl()
 
     init {

--- a/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/wrapper/impl/CloudAPIImpl.kt
+++ b/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/wrapper/impl/CloudAPIImpl.kt
@@ -33,7 +33,7 @@ import eu.thesimplecloud.api.screen.ICommandExecuteManager
 import eu.thesimplecloud.api.service.ICloudServiceManager
 import eu.thesimplecloud.api.service.version.IServiceVersionHandler
 import eu.thesimplecloud.api.service.version.ServiceVersionHandler
-import eu.thesimplecloud.api.service.version.ServiceVersionWebLoader
+import eu.thesimplecloud.api.service.version.ServiceVersionLoader
 import eu.thesimplecloud.api.servicegroup.ICloudServiceGroupManager
 import eu.thesimplecloud.api.sync.list.manager.ISynchronizedObjectListManager
 import eu.thesimplecloud.api.sync.list.manager.SynchronizedObjectListManager
@@ -48,7 +48,7 @@ class CloudAPIImpl : CloudAPI() {
     private val cloudPlayerManager = CloudPlayerManagerImpl()
     private val eventManager = EventManagerImpl()
     private val synchronizedObjectListManager = SynchronizedObjectListManager()
-    private val serviceVersionHandler = ServiceVersionHandler(ServiceVersionWebLoader.loadVersions())
+    private val serviceVersionHandler = ServiceVersionHandler(ServiceVersionLoader.loadVersions())
     private val languageManager = LanguageManager()
 
     init {

--- a/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/wrapper/process/filehandler/ServiceVersionJarLoader.kt
+++ b/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/wrapper/process/filehandler/ServiceVersionJarLoader.kt
@@ -27,6 +27,7 @@ import eu.thesimplecloud.api.service.version.ServiceVersion
 import eu.thesimplecloud.api.utils.Downloader
 import eu.thesimplecloud.api.utils.ZipUtils
 import java.io.File
+import java.io.FileNotFoundException
 
 class ServiceVersionJarLoader {
 
@@ -34,6 +35,9 @@ class ServiceVersionJarLoader {
     fun loadVersionFile(serviceVersion: ServiceVersion): File {
         val file = File(DirectoryPaths.paths.minecraftJarsPath + serviceVersion.name + ".jar")
         if (!file.exists()){
+            if(serviceVersion.downloadURL.isBlank() || serviceVersion.downloadURL.equals("noDownload", ignoreCase = true))
+                throw FileNotFoundException("Service version " + serviceVersion.name + " is set to no download but does not exist in minecraftJars folder.")
+
             Downloader().userAgentDownload(serviceVersion.downloadURL, file)
             //delete json to prevent bugs in spigot version 1.8
             ZipUtils().deletePath(file, "com/google/gson/")


### PR DESCRIPTION
Added custom version support in form of a local-mc-versions.json located in the storage folder.

You can add a version by adding another element to the json array of versions. The element must contain a name, a serviceAPIType and a downloadURL, which can either be "noDownload" or a URL to download the version.