### PR TITLE
Added api-version to plugin.yml's of bukkit plugins

### DIFF
--- a/simplecloud-modules/simplecloud-module-permission/src/main/resources/plugin.yml
+++ b/simplecloud-modules/simplecloud-module-permission/src/main/resources/plugin.yml
@@ -6,4 +6,6 @@ main: eu.thesimplecloud.module.permission.service.spigot.SpigotPluginMain
 
 depend: [SimpleCloud-Plugin]
 
+api-version: 1.13
+
 commands:

--- a/simplecloud-modules/simplecloud-module-sign/src/main/resources/plugin.yml
+++ b/simplecloud-modules/simplecloud-module-sign/src/main/resources/plugin.yml
@@ -6,6 +6,8 @@ main: eu.thesimplecloud.module.sign.service.BukkitPluginMain
 
 depend: [SimpleCloud-Plugin]
 
+api-version: 1.13
+
 commands:
   cloudsigns:
     permission: cloud.command.signs

--- a/simplecloud-plugin/src/main/resources/plugin.yml
+++ b/simplecloud-plugin/src/main/resources/plugin.yml
@@ -4,4 +4,6 @@ author: Wetterbericht
 
 main: eu.thesimplecloud.plugin.server.CloudSpigotPlugin
 
+api-version: 1.13
+
 commands:


### PR DESCRIPTION
If no api-version is specified in plugin.yml, Spigot servers above 1.12 load the legacy item support. This causes delays at startup.

Tested Spigot: Paper build 621:
![grafik](https://user-images.githubusercontent.com/64549494/115992200-b98eff80-a5cc-11eb-87d7-43e03598352a.png)


Console:
![grafik](https://user-images.githubusercontent.com/64549494/115992189-9ebc8b00-a5cc-11eb-98e9-bfdc656056e0.png)
