### PR TITLE
Add API-Version and other general changes

### DIFF
--- a/simplecloud-modules/simplecloud-module-permission/src/main/resources/plugin.yml
+++ b/simplecloud-modules/simplecloud-module-permission/src/main/resources/plugin.yml
@@ -6,4 +6,6 @@ main: eu.thesimplecloud.module.permission.service.spigot.SpigotPluginMain
 
 depend: [SimpleCloud-Plugin]
 
+api-version: 1.13
+
 commands:

--- a/simplecloud-modules/simplecloud-module-sign/src/main/resources/plugin.yml
+++ b/simplecloud-modules/simplecloud-module-sign/src/main/resources/plugin.yml
@@ -6,6 +6,8 @@ main: eu.thesimplecloud.module.sign.service.BukkitPluginMain
 
 depend: [SimpleCloud-Plugin]
 
+api-version: 1.13
+
 commands:
   cloudsigns:
     permission: cloud.command.signs

--- a/simplecloud-mongoinstaller/src/main/java/eu/thesimplecloud/mongoinstaller/InstallerEnum.java
+++ b/simplecloud-mongoinstaller/src/main/java/eu/thesimplecloud/mongoinstaller/InstallerEnum.java
@@ -35,7 +35,7 @@ public enum InstallerEnum {
     DEBIAN_10("echo \"deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.2 main\" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list"),
     DEBIAN_9("echo \"deb http://repo.mongodb.org/apt/debian stretch/mongodb-org/4.2 main\" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list"),
     UBUNTU_18("echo \"deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.2 multiverse\" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list"),
-    DEBIAN_16("echo \"deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse\" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list")
+    UBUNTU_16("echo \"deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.2 multiverse\" | sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list")
 
     ;
 

--- a/simplecloud-plugin/src/main/resources/plugin.yml
+++ b/simplecloud-plugin/src/main/resources/plugin.yml
@@ -4,4 +4,6 @@ author: Wetterbericht
 
 main: eu.thesimplecloud.plugin.server.CloudSpigotPlugin
 
+api-version: 1.13
+
 commands:

--- a/simplecloud-runner/src/main/kotlin/eu/thesimplecloud/runner/RunnerClassLoader.kt
+++ b/simplecloud-runner/src/main/kotlin/eu/thesimplecloud/runner/RunnerClassLoader.kt
@@ -33,12 +33,6 @@ import java.net.URLClassLoader
  */
 class RunnerClassLoader(urls: Array<URL>) : URLClassLoader(urls, getSystemClassLoader()) {
 
-    companion object {
-        init {
-            ClassLoader.registerAsParallelCapable()
-        }
-    }
-
     override fun addURL(url: URL?) {
         super.addURL(url)
     }


### PR DESCRIPTION
In this PR multiple general but also important changes have been made. None of them are critical to software stability in any way.

This PR fixes:
- Unecessary initzialization of spigots legacy item mode when used on servers >= 1.13 (#38)
- Wrong installation option. ( `DEBIAN_16` is now correctly `UBUNTU_16` )
- Redundant classloader registration as parallel
- Misbehaving if MOTD was empty

If there are any questions please comment directly onto the code-section . I'll be anwering and seeing forward to a fast merge!