### PR TITLE
Different Java versions for service versions

### DIFF
--- a/simplecloud-api/src/main/kotlin/eu/thesimplecloud/api/service/version/ServiceVersion.kt
+++ b/simplecloud-api/src/main/kotlin/eu/thesimplecloud/api/service/version/ServiceVersion.kt
@@ -33,5 +33,6 @@ import eu.thesimplecloud.api.service.version.type.ServiceAPIType
 data class ServiceVersion(
         val name: String,
         val serviceAPIType: ServiceAPIType,
-        val downloadURL: String
+        val downloadURL: String,
+        var javaCommand: String
 )

--- a/simplecloud-api/src/main/kotlin/eu/thesimplecloud/api/service/version/ServiceVersion.kt
+++ b/simplecloud-api/src/main/kotlin/eu/thesimplecloud/api/service/version/ServiceVersion.kt
@@ -34,5 +34,5 @@ data class ServiceVersion(
         val name: String,
         val serviceAPIType: ServiceAPIType,
         val downloadURL: String,
-        var javaCommand: String
+        val javaCommand: String
 )

--- a/simplecloud-api/src/main/kotlin/eu/thesimplecloud/api/service/version/loader/ServiceVersionWebLoader.kt
+++ b/simplecloud-api/src/main/kotlin/eu/thesimplecloud/api/service/version/loader/ServiceVersionWebLoader.kt
@@ -41,7 +41,6 @@ class ServiceVersionWebLoader : IServiceVersionLoader {
 
     override fun loadVersions(): List<ServiceVersion> {
         val version = this::class.java.`package`.implementationVersion.substring(0, 3)
-        //TODO add javaCommand
         val contentString = WebContentLoader().loadContent("https://api.thesimplecloud.eu/versions?implementationVersion[\$lte]=$version")
         return if (contentString == null) {
             loadFromFile()
@@ -63,7 +62,6 @@ class ServiceVersionWebLoader : IServiceVersionLoader {
 
         //Can be removed if the online versions file contains "javaCommand"
         val list = jsonLib.getObject(Array<ServiceVersion>::class.java).toList()
-        list.forEach { it.javaCommand = "java" }
-        return list
+        return list.map { ServiceVersion(it.name, it.serviceAPIType, it.downloadURL, it.javaCommand) }
     }
 }

--- a/simplecloud-api/src/main/kotlin/eu/thesimplecloud/api/service/version/loader/ServiceVersionWebLoader.kt
+++ b/simplecloud-api/src/main/kotlin/eu/thesimplecloud/api/service/version/loader/ServiceVersionWebLoader.kt
@@ -41,6 +41,7 @@ class ServiceVersionWebLoader : IServiceVersionLoader {
 
     override fun loadVersions(): List<ServiceVersion> {
         val version = this::class.java.`package`.implementationVersion.substring(0, 3)
+        //TODO add javaCommand
         val contentString = WebContentLoader().loadContent("https://api.thesimplecloud.eu/versions?implementationVersion[\$lte]=$version")
         return if (contentString == null) {
             loadFromFile()
@@ -56,7 +57,13 @@ class ServiceVersionWebLoader : IServiceVersionLoader {
 
     private fun processWebContent(contentString: String): List<ServiceVersion> {
         val jsonLib = JsonLib.fromJsonString(contentString)
+
+
         jsonLib.saveAsFile(file)
-        return jsonLib.getObject(Array<ServiceVersion>::class.java).toList()
+
+        //Can be removed if the online versions file contains "javaCommand"
+        val list = jsonLib.getObject(Array<ServiceVersion>::class.java).toList()
+        list.forEach { it.javaCommand = "java" }
+        return list
     }
 }

--- a/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/manager/setup/ServiceVersionSetup.kt
+++ b/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/manager/setup/ServiceVersionSetup.kt
@@ -46,6 +46,7 @@ class ServiceVersionSetup : ISetup {
     private lateinit var name: String
     private lateinit var serviceAPIType: ServiceAPIType
     private lateinit var downloadURL: String
+    private lateinit var javaCommand: String
 
     @SetupQuestion(0, "manager.setup.service-versions.question.name")
     fun nameSetup(name: String): Boolean {
@@ -74,9 +75,16 @@ class ServiceVersionSetup : ISetup {
         return true
     }
 
+    @SetupQuestion(3, "manager.setup.service-versions.question.java")
+    fun javaCommandSetup(javaCommand: String): Boolean {
+        this.javaCommand = javaCommand
+        Launcher.instance.consoleSender.sendPropertyInSetup("manager.setup.service-versions.question.java.success")
+        return true
+    }
+
     @SetupFinished
     fun setupFinished() {
-        val serviceVersion = ServiceVersion(name, serviceAPIType, downloadURL)
+        val serviceVersion = ServiceVersion(name, serviceAPIType, downloadURL, javaCommand)
         LocalServiceVersionHandler().saveServiceVersion(serviceVersion)
         val serviceVersionHandler = CloudAPI.instance.getServiceVersionHandler() as ManagerServiceVersionHandler
         serviceVersionHandler.reloadServiceVersions()

--- a/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/wrapper/process/CloudServiceProcess.kt
+++ b/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/wrapper/process/CloudServiceProcess.kt
@@ -164,7 +164,9 @@ class CloudServiceProcess(private val cloudService: ICloudService) : ICloudServi
         val jvmArguments = Wrapper.instance.jvmArgumentsConfig.jvmArguments.filter {
             it.groups.contains("all") || it.groups.contains(this.cloudService.getGroupName()) || it.groups.contains(this.cloudService.getServiceType().name)
         }
-        val commands = mutableListOf("java")
+
+        val startCommand = this.cloudService.getServiceVersion().javaCommand;
+        val commands = mutableListOf(startCommand)
 
         jvmArguments.forEach { commands.addAll(it.arguments) }
 

--- a/simplecloud-launcher/src/main/resources/language/de.json
+++ b/simplecloud-launcher/src/main/resources/language/de.json
@@ -160,6 +160,8 @@
   "manager.setup.service-versions.question.url": "Bitte gebe die Donwload-URL dieser Version an",
   "manager.setup.service-versions.question.url.invalid": "Die angegebene URL ist ungültig",
   "manager.setup.service-versions.question.url.success": "URL gesetzt",
+  "manager.setup.service-versions.question.java.success": "Java Start Befehl gesetzt",
+  "manager.setup.service-versions.question.java": "Bitte gebe den Java start Befehl ein (java = Standart)",
   "manager.setup.service-versions.finished": "Service-Version %NAME% erstellt",
   "manager.setup.wrapper.finished": "Der Wrapper %WRAPPER% wurde erstellt",
   "manager.setup.wrapper.question.host": "Welche IP-Adresse soll für den Wrapper verwendet werden? (this = IP-Adresse dieses Systems)",

--- a/simplecloud-launcher/src/main/resources/language/en.json
+++ b/simplecloud-launcher/src/main/resources/language/en.json
@@ -161,6 +161,8 @@
   "manager.setup.service-versions.question.url": "Please provide the download url of this version",
   "manager.setup.service-versions.question.url.invalid": "The specified URL is invalid",
   "manager.setup.service-versions.question.url.success": "URL set",
+  "manager.setup.service-versions.question.java.success": "Java start command set",
+  "manager.setup.service-versions.question.java": "Please provide the java start command (java = default)",
   "manager.setup.service-versions.finished": "Service version %NAME% created",
   "manager.setup.wrapper.finished": "Wrapper %NAME% created",
   "manager.setup.wrapper.question.host": "On which host starts the wrapper? (this = ip of this server)",

--- a/simplecloud-modules/simplecloud-module-chat-tab/src/main/kotlin/eu/thesimplecloud/module/prefix/service/spigot/listener/ChatListener.kt
+++ b/simplecloud-modules/simplecloud-module-chat-tab/src/main/kotlin/eu/thesimplecloud/module/prefix/service/spigot/listener/ChatListener.kt
@@ -20,6 +20,7 @@ class ChatListener : Listener {
     @EventHandler
     fun handleJoin(event: AsyncPlayerChatEvent) {
         val player = event.player
+        event.message = event.message.replace("%", "%%")
 
         val permissionPlayer = PermissionPool.instance.getPermissionPlayerManager().getCachedPermissionPlayer(player.uniqueId) ?: return
         val canWriteColored = event.player.hasPermission("cloud.module.chat.color")
@@ -39,7 +40,7 @@ class ChatListener : Listener {
     }
 
     private fun buildPrompt(information: TablistInformation): String {
-        return information.prefix + ChatColor.valueOf(information.color).toString() + "%1\$s" + information.suffix
+        return information.prefix + ChatColor.valueOf(information.color).toString() + "%1\$s"
     }
 
 }


### PR DESCRIPTION
Since 1.17 many plugins only work with java 16. That's why I made it possible to start different service versions with different java start commands.