### PR TITLE
Remove warning on start service

### DIFF
--- a/simplecloud-plugin/src/main/resources/plugin.yml
+++ b/simplecloud-plugin/src/main/resources/plugin.yml
@@ -6,4 +6,6 @@ main: eu.thesimplecloud.plugin.server.CloudSpigotPlugin
 
 api-version: 1.13
 
+softdepend: [SimpleCloud-Permission, SimpleCloud-Signs]
+
 commands:


### PR DESCRIPTION
Spigot always logs a warning when starting that modules are not dependent. Softdependent fixes that altogether. If the module is there, it will be loaded first. Otherwise not.