### PR TITLE
Change MongoDB connection URL encoding 

### DIFF
--- a/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/manager/database/MongoOfflineCloudPlayerHandler.kt
+++ b/simplecloud-base/src/main/kotlin/eu/thesimplecloud/base/manager/database/MongoOfflineCloudPlayerHandler.kt
@@ -40,6 +40,7 @@ import org.litote.kmongo.KMongo
 import org.litote.kmongo.find
 import org.litote.kmongo.findOne
 import org.litote.kmongo.getCollection
+import java.net.URLEncoder
 import java.util.*
 
 class MongoOfflineCloudPlayerHandler(val databaseConnectionInformation: DatabaseConnectionInformation) :
@@ -72,9 +73,9 @@ class MongoOfflineCloudPlayerHandler(val databaseConnectionInformation: Database
     private fun getConnectionString(): ConnectionString {
         val host = databaseConnectionInformation.host
         val port = databaseConnectionInformation.port
-        val databaseName = databaseConnectionInformation.databaseName
-        val userName = databaseConnectionInformation.userName
-        val password = databaseConnectionInformation.password
+        val databaseName = URLEncoder.encode(databaseConnectionInformation.databaseName,"utf-8")
+        val userName = URLEncoder.encode(databaseConnectionInformation.userName, "utf-8")
+        val password = URLEncoder.encode(databaseConnectionInformation.password,"utf-8")
         if (password.isBlank() || userName.isBlank()) {
             return ConnectionString("mongodb://$host:$port/?authSource=$databaseName")
         }


### PR DESCRIPTION
MongoDB supports utf-8 database names, usernames and passwords. Therefor those parameters need to be properly encoded so they can be used inside an URL.

This PR changed:

- username, databaseName, password fields are now encoded before passed into Mongodb Connection URL.


Fixed #108

