### PR TITLE
fix: multiple lines were not split properly

### DIFF
--- a/simplecloud-modules/simplecloud-module-proxy/src/main/kotlin/eu/thesimplecloud/module/proxy/service/bungee/listener/BungeeListener.kt
+++ b/simplecloud-modules/simplecloud-module-proxy/src/main/kotlin/eu/thesimplecloud/module/proxy/service/bungee/listener/BungeeListener.kt
@@ -36,6 +36,7 @@ import net.md_5.bungee.api.event.ServerSwitchEvent
 import net.md_5.bungee.api.plugin.Listener
 import net.md_5.bungee.event.EventHandler
 import net.md_5.bungee.event.EventPriority
+import java.util.*
 
 /**
  * Created by IntelliJ IDEA.
@@ -126,15 +127,21 @@ class BungeeListener(private val plugin: BungeePluginMain) : Listener {
         val maxPlayers = CloudPlugin.instance.thisService().getServiceGroup().getMaxPlayers()
 
         if (playerInfo != null && playerInfo.isNotEmpty()) {
-            val playerInfoString = ProxyHandler.replaceString(playerInfo.joinToString("\n"))
-            val playerInfoComponent = ProxyHandler.getHexColorComponent(playerInfoString)
-            val sample = arrayOf(
-                ServerPing.PlayerInfo(
-                    LegacyComponentSerializer.legacy('§').serialize(playerInfoComponent),
-                    ""
+            val sample = mutableListOf<ServerPing.PlayerInfo>()
+
+            playerInfo.forEach {
+                val playerInfoString = ProxyHandler.replaceString(it)
+                val playerInfoComponent = ProxyHandler.getHexColorComponent(playerInfoString)
+
+                sample.add(
+                    ServerPing.PlayerInfo(
+                        LegacyComponentSerializer.legacy('§').serialize(playerInfoComponent),
+                        UUID.randomUUID()
+                    )
                 )
-            )
-            response.players = ServerPing.Players(maxPlayers, onlinePlayers, sample)
+            }
+
+            response.players = ServerPing.Players(maxPlayers, onlinePlayers, sample.toTypedArray())
 
             return
         }

--- a/simplecloud-modules/simplecloud-module-proxy/src/main/kotlin/eu/thesimplecloud/module/proxy/service/velocity/listener/VelocityListener.kt
+++ b/simplecloud-modules/simplecloud-module-proxy/src/main/kotlin/eu/thesimplecloud/module/proxy/service/velocity/listener/VelocityListener.kt
@@ -28,6 +28,7 @@ import com.velocitypowered.api.event.player.ServerConnectedEvent
 import com.velocitypowered.api.event.player.ServerPreConnectEvent
 import com.velocitypowered.api.event.proxy.ProxyPingEvent
 import com.velocitypowered.api.proxy.server.ServerPing
+import com.velocitypowered.api.proxy.server.ServerPing.SamplePlayer
 import eu.thesimplecloud.module.proxy.extensions.mapToLowerCase
 import eu.thesimplecloud.module.proxy.service.ProxyHandler
 import eu.thesimplecloud.module.proxy.service.velocity.VelocityPluginMain
@@ -124,14 +125,21 @@ class VelocityListener(val plugin: VelocityPluginMain) {
         val maxPlayers = CloudPlugin.instance.thisService().getServiceGroup().getMaxPlayers()
 
         val playerSamples = if (playerInfo != null && playerInfo.isNotEmpty()) {
-            val playerInfoString = ProxyHandler.replaceString(playerInfo.joinToString("\n"))
-            val playerInfoColorComponent = ProxyHandler.getHexColorComponent(playerInfoString)
-            listOf(
-                ServerPing.SamplePlayer(
-                    LegacyComponentSerializer.legacy('§').serialize(playerInfoColorComponent),
-                    UUID.randomUUID()
+            val sample = mutableListOf<SamplePlayer>()
+
+            playerInfo.forEach {
+                val playerInfoString = ProxyHandler.replaceString(it)
+                val playerInfoComponent = ProxyHandler.getHexColorComponent(playerInfoString)
+
+                sample.add(
+                    SamplePlayer(
+                        LegacyComponentSerializer.legacy('§').serialize(playerInfoComponent),
+                        UUID.randomUUID()
+                    )
                 )
-            )
+            }
+
+            sample
         } else {
             emptyList()
         }


### PR DESCRIPTION
Before this, the player info (the thing that pops up when you're hovering over the players amount in the server list) worked, but only with one line. If you wanted to add two lines, it would work but only on older versions and not on newer ones:

![grafik](https://github.com/theSimpleCloud/SimpleCloud/assets/63158842/d5331f98-6d23-4fc3-a3c1-4214fcafc8d3)

This was because the list of lines in the config was set together in one string using String#joinToString with the '\n' and for some reason, newer versions can't deal with that. I changed the code so that each line has it's own Profile (these lines are called profiles) and there isn't only one Profile that represents all lines:

![grafik](https://github.com/theSimpleCloud/SimpleCloud/assets/63158842/2baa2aa5-8ee4-4d66-afa1-9853e054f98a)