### PR TITLE
Add local players count replacement

### DIFF
--- a/simplecloud-modules/simplecloud-module-proxy/src/main/kotlin/eu/thesimplecloud/module/proxy/service/ProxyHandler.kt
+++ b/simplecloud-modules/simplecloud-module-proxy/src/main/kotlin/eu/thesimplecloud/module/proxy/service/ProxyHandler.kt
@@ -107,6 +107,7 @@ object ProxyHandler {
             .replace("%SERVER%", server.getName())
             .replace("%DISPLAYNAME%", server.getDisplayName())
             .replace("%SERVER_GROUP%", server.getGroupName())
+            .replace("%LOCAL_ONLINE_PLAYERS%", server.getOnlineCount().toString())
     }
 
     fun replaceString(message: String, server: ICloudService, uuid: UUID): String {


### PR DESCRIPTION
This pull request simply adds `%LOCAL_ONLINE_PLAYERS%` as a replacement for the online player count of the server that the player is currently online on.