### PR TITLE
Add custom chat formats

### DIFF
--- a/simplecloud-modules/simplecloud-module-chat-tab/src/main/kotlin/eu/thesimplecloud/module/prefix/manager/config/ChatTabConfig.kt
+++ b/simplecloud-modules/simplecloud-module-chat-tab/src/main/kotlin/eu/thesimplecloud/module/prefix/manager/config/ChatTabConfig.kt
@@ -33,6 +33,7 @@ import eu.thesimplecloud.api.property.IProperty
  */
 class ChatTabConfig(
         val chatFormat: String = "%PLAYER% §8» §7%MESSAGE%",
+        val chatFormats: MutableMap<String, String> = mutableMapOf("Admin" to "§r\n%PLAYER% §8» §7%MESSAGE%\n§r"),
         val informationList: List<TablistInformation> = listOf(TablistInformation()),
         val disabledServerGroups: List<String> = emptyList(),
         val delay: MutableMap<String, Long> = mutableMapOf(

--- a/simplecloud-modules/simplecloud-module-chat-tab/src/main/kotlin/eu/thesimplecloud/module/prefix/service/spigot/listener/ChatListener.kt
+++ b/simplecloud-modules/simplecloud-module-chat-tab/src/main/kotlin/eu/thesimplecloud/module/prefix/service/spigot/listener/ChatListener.kt
@@ -48,7 +48,8 @@ class ChatListener : Listener {
             PermissionPool.instance.getPermissionPlayerManager().getCachedPermissionPlayer(player.uniqueId) ?: return
         val canWriteColored = event.player.hasPermission("cloud.module.chat.color")
         val tablistInformation = TablistHelper.getTablistInformationByUUID(player.uniqueId) ?: return
-        val format = ChatColor.translateAlternateColorCodes('&', ChatTabConfig.getConfig().chatFormat)
+
+        val format = ChatColor.translateAlternateColorCodes('&', ChatTabConfig.getConfig().chatFormats[permissionPlayer.getHighestPermissionGroup().getName()] ?: ChatTabConfig.getConfig().chatFormat)
             .replace("%PLAYER%", buildPrompt(tablistInformation))
             .replace("%NAME%", event.player.name)
             .replace("%PRIORITY%", tablistInformation.priority.toString())


### PR DESCRIPTION
With this feature, you can now set different chat formats for specific permission groups. If you want to have an empty line above and under the actual line with the message to let the message stand out in chat if an Admin messages for example, you can now set a custom chat format for just the Admin permission group in the config

If there's no custom format set, the default one will be used